### PR TITLE
updated settings button to match figma designs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,15 @@
 {
     "presets": [
         "next/babel"
+    ],
+    "plugins": [
+        [
+            "styled-components",
+            {
+                "ssr": true,
+                "displayName": true,
+                "preprocess": false
+            }
+        ]
     ]
 }

--- a/assets/Icon.tsx
+++ b/assets/Icon.tsx
@@ -40,7 +40,9 @@ export type IconType =
   | "invite"
   | "inviteTrash"
   | "inviteAdd"
-  | "ex";
+  | "ex"
+  | "logout"
+  | "dropMenu";
 
 const IconSvgs: Record<IconType, React.ReactElement> = {
   calendar: (
@@ -625,6 +627,16 @@ const IconSvgs: Record<IconType, React.ReactElement> = {
         strokeWidth="1.45"
         strokeLinecap="round"
       />
+    </svg>
+  ),
+  logout: (
+    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M16 18H7C5.89543 18 5 17.1046 5 16V12H7V16H16V2H7V6H5V2C5 0.89543 5.89543 0 7 0H16C17.1046 0 18 0.89543 18 2V16C18 17.1046 17.1046 18 16 18ZM9 13V10H0V8H9V5L14 9L9 13Z" fill="#253C85" />
+    </svg>
+  ),
+  dropMenu: (
+    <svg width="6" height="3" viewBox="0 0 6 3" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M6 0H0L3 3L6 0Z" fill="white" />
     </svg>
   ),
 };

--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -4,14 +4,19 @@ import Head from "next/head";
 import SideNavbar from "./SideNavbar/SideNavbar";
 import ProfileSettings from "../ProfileSettings/ProfileSettings";
 import styles from "./Layout.module.css";
+import { boolean } from "yup";
 
 type LayoutProps = {
   title?: string;
+  adminName?: string;
+  onProfile?: boolean;
 };
 
 const Layout: React.FC<LayoutProps> = ({
   children,
   title = "Sunday Friends",
+  adminName = "Admin",
+  onProfile = false,
 }) => {
   return (
     <div className={styles["layout-container"]}>
@@ -24,7 +29,7 @@ const Layout: React.FC<LayoutProps> = ({
         <SideNavbar />
         {children}
         <div className={styles["profile-settings"]}>
-          <ProfileSettings />
+          <ProfileSettings adminName={adminName} onProfile={onProfile} />
         </div>
       </div>
     </div>

--- a/components/ProfileSettings/ProfileSettings.tsx
+++ b/components/ProfileSettings/ProfileSettings.tsx
@@ -1,57 +1,114 @@
-import React from "react";
+import React, { useState } from "react";
 import { Button } from "@mui/material";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
-import styles from "../ProfileSettings/ProfileSettings.module.css";
 import Divider from "@mui/material/Divider";
 import { useRouter } from "next/router";
 import { signOut } from "../../firebase/auth";
 import Icon from "../../assets/Icon";
+import { styled } from "@mui/styles";
 
-const ProfileSettings: React.FunctionComponent = () => {
-  const [anchorEl, setAnchorEl] = React.useState(null);
-  const open = Boolean(anchorEl);
+type ProfileSettingsProps = {
+  adminName: string;
+  onProfile: boolean;
+};
+
+const SettingsMenuItem = styled(MenuItem)(() => ({
+  display: "flex",
+  justifyContent: "space-around",
+  alignItems: "center",
+  fontFamily: "Avenir",
+  "&:hover": {
+    backgroundColor: "white"
+  }
+}));
+
+const ProfileSettings: React.FunctionComponent<ProfileSettingsProps> = ({
+  adminName,
+  onProfile,
+}) => {
+  const name = adminName.split(" ")[0]
+  const [anchorEl, setAnchorEl] = useState<Element>(null);
   const router = useRouter();
   const handleClick = (event) => {
     setAnchorEl(event.currentTarget);
   };
-  const handleClose = () => {
+
+  const handleClose = (): void => {
     setAnchorEl(null);
   };
-  const handleSignOut = () => {
+
+  const handleSignOut = (): void => {
     signOut();
     router.push("/");
   };
+
+  const handleRedirect = (): void => {
+    router.push("/profile");
+  };
+
   return (
-    <div>
+    <>
       <Button
-        variant="contained"
-        className={styles.button}
         onClick={handleClick}
+        disableRipple
         sx={{
-          display: {
-            fontFamily: "Avenir",
-            height: "31px",
-            textTransform: "capitalize",
+          width: "85px",
+          height: "30px",
+          borderRadius: "26px",
+          backgroundColor: "#5A6AA2",
+          display: "flex",
+          fontFamily: "Avenir",
+          textTransform: "none",
+          "&:hover": {
+            backgroundColor: "#5A6AA2",
           },
+          justifyContent: "space-around",
+          color: "white",
         }}
       >
-        Cindy ▼
+        {name}
+        <Icon type="dropMenu" />
       </Button>
       <Menu
-        id="demo-customized-menu"
         MenuListProps={{
-          "aria-labelledby": "demo-customized-button",
+          "aria-labelledby": "basic-button",
+        }}
+        PaperProps={{
+          style: {
+            width: "145px",
+            borderRadius: "10px",
+            border: "2px solid #E6ECFE",
+            boxSizing: "border-box",
+            boxShadow: "0px 0px 10px rgba(0, 0, 0, 0.2)"
+          },
         }}
         anchorEl={anchorEl}
-        open={open}
+        open={Boolean(anchorEl)}
         onClose={handleClose}
+        variant="menu"
+        transformOrigin={{
+          vertical: "top",
+          horizontal: 40,
+        }}
       >
-        <MenuItem onClick={handleSignOut} disableRipple>
-          Logout{" "}
-        </MenuItem>
+        <SettingsMenuItem disabled={onProfile} onClick={handleRedirect} disableRipple>
+          <Icon type="settings" />
+          Settings
+        </SettingsMenuItem>
+        <Divider
+          sx={{
+            display: {
+              background: "#E6ECFE"
+            }
+          }}
+        />
+        <SettingsMenuItem onClick={handleSignOut} disableRipple>
+          <Icon type="logout" />
+          Logout
+        </SettingsMenuItem>
       </Menu>
-    </div>
+    </>
   );
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,33 @@
         }
       }
     },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
+      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.16.7"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
     "@babel/helper-compilation-targets": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.15.4.tgz",
@@ -2969,6 +2996,52 @@
         "cosmiconfig": "^6.0.0",
         "resolve": "^1.12.0"
       }
+    },
+    "babel-plugin-styled-components": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.0.6.tgz",
+      "integrity": "sha512-Sk+7o/oa2HfHv3Eh8sxoz75/fFvEdHsXV4grdeHufX0nauCmymlnN0rGhIvfpMQSJMvGutJ85gvCGea4iqmDpg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.16.0",
+        "@babel/helper-module-imports": "^7.16.0",
+        "babel-plugin-syntax-jsx": "^6.18.0",
+        "lodash": "^4.17.11",
+        "picomatch": "^2.3.0"
+      },
+      "dependencies": {
+        "@babel/helper-module-imports": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+          "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.16.7"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.16.7",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+          "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+          "dev": true
+        },
+        "@babel/types": {
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
+      }
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+      "dev": true
     },
     "babel-preset-current-node-syntax": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@typescript-eslint/eslint-plugin": "^5.3.0",
     "@typescript-eslint/parser": "^5.3.0",
     "babel-jest": "^27.4.6",
+    "babel-plugin-styled-components": "^2.0.6",
     "eslint": "^7.32.0",
     "eslint-config-next": "11.1.2",
     "eslint-config-prettier": "^8.3.0",

--- a/pages/admins/index.tsx
+++ b/pages/admins/index.tsx
@@ -109,7 +109,7 @@ const AdminPage: React.FunctionComponent<AdminPageProps> = ({
   });
 
   return (
-    <Layout title="Admins">
+    <Layout title="Admins" adminName={currentAdmin.name}>
       <main className={styles["main"]}>
         <div className={styles["header"]}>
           <Icon className={styles["admin-icon"]} type={"admin"}></Icon>

--- a/pages/profile/index.tsx
+++ b/pages/profile/index.tsx
@@ -84,7 +84,7 @@ const ProfileSettingsPage: React.FunctionComponent<ProfileSettingsPageProps> =
     };
 
     return (
-      <Layout title="Profile">
+      <Layout title="Profile" adminName={currentAdmin.name} onProfile={true}>
         <div className={styles.page}>
           <div className={styles.pagetitle}>
             <Icon type="settings"></Icon>

--- a/pages/transactions/index.tsx
+++ b/pages/transactions/index.tsx
@@ -159,7 +159,7 @@ const TransactionsPage: React.FunctionComponent<TransactionPageProps> = ({
   const uploadOpen = Boolean(uploadAnchorEl);
   const uploadpopoverid = uploadOpen ? "upload-popover" : undefined;
   return (
-    <Layout title="Transactions">
+    <Layout title="Transactions" adminName={currentAdmin.name}>
       <div className={styles["screen"]}>
         <div className={styles["container"]}>
           <div className={styles["title-div"]}>

--- a/pages/users/index.tsx
+++ b/pages/users/index.tsx
@@ -36,7 +36,7 @@ const UsersPage: React.FunctionComponent<UsersPageProps> = ({
     router.replace(router.asPath);
   };
   return (
-    <Layout title="Users">
+    <Layout title="Users" adminName={currentAdmin.name}>
       <Modal open={isOpen}>
         <div className={styles["newFamModal"]}>
           <div className={styles["modalHeadContanier"]}>


### PR DESCRIPTION
Updated dropdown menu from profile settings button to match figma and allow users to navigate to their profile page and sign out.

## Testing

- Click on button and see that settings and log out are available
- check that settings navigates user to profile page
- check that logout button actually logs you out
- check that the settings button is disabled on the profile page

## Screenshots

<img width="394" alt="Screen Shot 2022-03-13 at 10 35 24 PM" src="https://user-images.githubusercontent.com/28970991/158111316-eff55db1-0257-44e8-87c0-09b3c1ce4a18.png">
<img width="1429" alt="Screen Shot 2022-03-13 at 10 35 41 PM" src="https://user-images.githubusercontent.com/28970991/158111320-b887e18a-15b0-4c34-a643-b51c5c07ad66.png">


CC: @jacobjk01 @hukellyy
